### PR TITLE
Change the printed image witdh (resolve #44)

### DIFF
--- a/src/android/BluetoothPrinter.java
+++ b/src/android/BluetoothPrinter.java
@@ -656,7 +656,7 @@ public class BluetoothPrinter extends CordovaPlugin {
             int mWidth = bitmap.getWidth();
             int mHeight = bitmap.getHeight();
 
-            bitmap = resizeImage(bitmap, 48 * 8, mHeight);
+            bitmap = resizeImage(bitmap, 48 * 12, mHeight);
 
             byte[] bt = decodeBitmapBase64(bitmap);
 


### PR DESCRIPTION
Change the printed image witdh:
    * expand the image's witdh to cover all the 80mm page's witdh

resolve the [#44](https://github.com/CesarBalzer/Cordova-Plugin-BTPrinter/issues/44)