### PR TITLE
Add configurable paper width support to printBase64 method

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ BTPrinter.printBase64(function(data){
 },function(err){
     console.log("Error");
     console.log(err);
-}, "Image Base64 String",'0');//base64 string, align
+}, "Image Base64 String",'0', 32);//base64 string, align, paper width (32 is the default and the param is optional)
 ```
 
 ### Print title with size and align

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-btprinter",
-  "version": "0.0.1-dev",
+  "version": "1.0.0",
   "description": "A cordova plugin for bluetooth printer for android platform.",
   "cordova": {
     "id": "cordova-plugin-btprinter",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CesarBalzer/Cordova-Plugin-BTPrinter.git"
+    "url": "git+https://github.com/ppicapietra/Cordova-Plugin-BTPrinter.git"
   },
   "keywords": [
     "cordova",
@@ -25,16 +25,13 @@
     "ecosystem:cordova",
     "cordova-android"
   ],
-  "engines": [
-    {
-      "name": "cordova",
-      "version": ">=3.0.0"
-    }
-  ],
-  "author": "Cesar E. Balzer",
+  "engines": {
+    "cordova": ">=3.0.0"
+  },
+  "author": "Pablo Picapietra",
   "license": "Apache 2.0",
   "bugs": {
-    "url": "https://github.com/CesarBalzer/Cordova-Plugin-BTPrinter/issues"
+    "url": "https://github.com/ppicapietra/Cordova-Plugin-BTPrinter/issues"
   },
-  "homepage": "https://github.com/CesarBalzer/Cordova-Plugin-BTPrinter#readme"
+  "homepage": "https://github.com/ppicapietra/Cordova-Plugin-BTPrinter#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,16 +2,16 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-btprinter"
-        version="0.1.0-dev">
+        version="1.0.0">
 
    <name>BTPrinter</name>
    <description>A cordova plugin for bluetooth printer for android platform.</description>
 
-   <repo>https://github.com/CesarBalzer/Cordova-Plugin-BTPrinter</repo>
+   <repo>https://github.com/ppicapietra/Cordova-Plugin-BTPrinter</repo>
    <license>Apache 2.0</license>
    <keywords>cordova, bluetooth, printer, pos, text, barcode, image, base64, qrcode</keywords>
 
-   <author>Cesar E. Balzer</author>
+   <author>Pablo Picapietra</author>
 
    <!-- cordova -->
    <engines>

--- a/src/android/BluetoothPrinter.java
+++ b/src/android/BluetoothPrinter.java
@@ -89,6 +89,8 @@ public class BluetoothPrinter extends CordovaPlugin {
 	public static final byte[] BARCODE_ITF = { 0x1D, 0x6B, 0x05 };
 	public static final byte[] BARCODE_CODABAR = { 0x1D, 0x6B, 0x06 };
 
+    public static final int DEFAULT_PAPER_WIDTH = 32;
+
     public static final int REQUEST_BLUETOOTH_PERMISSION = 1;
 
     @Override
@@ -157,7 +159,8 @@ public class BluetoothPrinter extends CordovaPlugin {
             try {
                 String msg = args.getString(0);
                 Integer align = Integer.parseInt(args.getString(1));
-                printBase64(callbackContext, msg, align);
+                Integer paperWidth = args.length() > 2 ? Integer.parseInt(args.getString(2)) : DEFAULT_PAPER_WIDTH; // Default to 32 if undefined
+                printBase64(callbackContext, msg, align, paperWidth);
             } catch (IOException e) {
                 Log.e(LOG_TAG, e.getMessage());
                 e.printStackTrace();
@@ -655,7 +658,7 @@ public class BluetoothPrinter extends CordovaPlugin {
     }
 
     // This will send data to bluetooth printer
-    boolean printBase64(CallbackContext callbackContext, String msg, Integer align) throws IOException {
+    boolean printBase64(CallbackContext callbackContext, String msg, Integer align, Integer paperWidth) throws IOException {
         try {
 
             final String encodedString = msg;
@@ -668,7 +671,7 @@ public class BluetoothPrinter extends CordovaPlugin {
             int mWidth = bitmap.getWidth();
             int mHeight = bitmap.getHeight();
 
-            bitmap = resizeImage(bitmap, 48 * 12, mHeight);
+            bitmap = resizeImage(bitmap, paperWidth * 12, mHeight);
 
             byte[] bt = decodeBitmapBase64(bitmap);
 


### PR DESCRIPTION
Fix issue with base64 print method by making paper width configurable. Users can now pass the paperWidth parameter to specify a custom width or leave it undefined to default to 32. This resolves rendering issues when printing on narrower paper widths